### PR TITLE
Fix shadowsocksr source address

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=shadowsocksR-libev
-PKG_VERSION:=v20170613
+PKG_VERSION:=v20170907
 PKG_RELEASE:=1pre
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_RELEASE).tar.gz
-PKG_SOURCE_URL:=https://github.com/breakwa11/shadowsocks-libev.git
+PKG_SOURCE_URL:=https://github.com/zhaoxitao/shadowsocksr-libev.git
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=f713aa981169d35ff9483b295d1209c35117d70c
+PKG_SOURCE_VERSION:=bf324d848cffa0b5b567cfa6d31c0fb1ec096ec6
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_MAINTAINER:=breakwa11
+PKG_MAINTAINER:=zhaoxitao
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(BUILD_VARIANT)/$(PKG_NAME)-$(PKG_VERSION)
 
@@ -24,7 +24,7 @@ define Package/shadowsocksr-libev/Default
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Lightweight Secured Socks5 Proxy
-  URL:=https://github.com/breakwa11/shadowsocks-libev
+  URL:=https://github.com/zhaoxitao/shadowsocksr-libev
 endef
 
 # default packages

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ ShadowsocksR-libev-full for OpenWrt
  当前版本: v20170907  
  
  v20170907 更新:  
- > 修正 shadowsocksr-libev 源地址  
+ > 修正 shadowsocksr-libev 源地址  
  > 支持加密协议 "none"  
  > 支持混淆协议(Protocol) "auth_chain_a"  
  > 支持混淆方式(Obfs) "tls1.2_ticket_auth"  

--- a/README.md
+++ b/README.md
@@ -5,7 +5,14 @@ ShadowsocksR-libev-full for OpenWrt
 ---
 
  本项目是 [ShadowsocksR-libev][1] 在 OpenWrt 上的移植。   
- 当前版本: v20170613  
+ 当前版本: v20170907  
+ 
+ v20170907 更新:
+ > 修正源 shadowsocksr-live 地址
+ > 支持加密协议 "none"
+ > 支持混淆协议(Protocol) "auth_chain_a"
+ > 支持混淆方式(Obfs) "tls1.2_ticket_auth"
+"
  
  [预编译 LEDE ipk 下载][R]
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ ShadowsocksR-libev-full for OpenWrt
  当前版本: v20170907  
  
  v20170907 更新:  
- > 修正源 shadowsocksr-live 地址  
+ > 修正 shadowsocksr-libev 源地址  
  > 支持加密协议 "none"  
  > 支持混淆协议(Protocol) "auth_chain_a"  
  > 支持混淆方式(Obfs) "tls1.2_ticket_auth"  

--- a/README.md
+++ b/README.md
@@ -7,12 +7,11 @@ ShadowsocksR-libev-full for OpenWrt
  本项目是 [ShadowsocksR-libev][1] 在 OpenWrt 上的移植。   
  当前版本: v20170907  
  
- v20170907 更新:
- > 修正源 shadowsocksr-live 地址
- > 支持加密协议 "none"
- > 支持混淆协议(Protocol) "auth_chain_a"
- > 支持混淆方式(Obfs) "tls1.2_ticket_auth"
-"
+ v20170907 更新:  
+ > 修正源 shadowsocksr-live 地址  
+ > 支持加密协议 "none"  
+ > 支持混淆协议(Protocol) "auth_chain_a"  
+ > 支持混淆方式(Obfs) "tls1.2_ticket_auth"  
  
  [预编译 LEDE ipk 下载][R]
 

--- a/files/dns-forwarder.config
+++ b/files/dns-forwarder.config
@@ -2,4 +2,4 @@ config dns-forwarder
     option enable '1'
     option listen_addr '0.0.0.0'
     option listen_port '5353'
-    option dns_servers '8.8.8.8'
+    option dns_servers '208.67.220.220:443'

--- a/files/firewall.user
+++ b/files/firewall.user
@@ -8,6 +8,7 @@
 
 ipset create gfwlist hash:net
 ipset add gfwlist 8.8.8.8
+ipset add gfwlist 208.67.220.220
 ipset add gfwlist 91.108.4.0/22
 ipset add gfwlist 91.108.56.0/22
 ipset add gfwlist 109.239.140.0/24
@@ -18,3 +19,4 @@ iptables -t nat -I OUTPUT -p tcp -m set --match-set gfwlist dst -j REDIRECT --to
 
 iptables -t nat -I PREROUTING -i br-lan -p udp -d 8.8.4.4 --dport 53 -j REDIRECT --to-ports 53
 iptables -t nat -I PREROUTING -i br-lan -p udp -d 8.8.8.8 --dport 53 -j REDIRECT --to-ports 53
+iptables -t nat -I PREROUTING -i br-lan -p udp -d 208.67.220.220 --dport 443 -j REDIRECT --to-ports 443


### PR DESCRIPTION
Fix shadowsocksr source address and change remote DNS server to OpenDNS for improve stability.
After testing supported encryption "none", protocol "auth_chian_a" and ofbs "tls1.2_ticket_auth".
Apply merge if you allow.
Thank you.